### PR TITLE
Add support for statistics

### DIFF
--- a/src/TeamCitySharp/ActionTypes/IStatistics.cs
+++ b/src/TeamCitySharp/ActionTypes/IStatistics.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using TeamCitySharp.DomainEntities;
+
+namespace TeamCitySharp.ActionTypes
+{
+    public interface IStatistics
+    {
+        List<Property> GetByBuildId(string buildId);
+    }
+}

--- a/src/TeamCitySharp/ActionTypes/Statistics.cs
+++ b/src/TeamCitySharp/ActionTypes/Statistics.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using TeamCitySharp.Connection;
+using TeamCitySharp.DomainEntities;
+
+namespace TeamCitySharp.ActionTypes
+{
+    public class Statistics : IStatistics
+    {
+        private readonly TeamCityCaller _caller;
+
+        internal Statistics(TeamCityCaller caller)
+        {
+            _caller = caller;
+        }
+
+        public List<Property> GetByBuildId(string buildId)
+        {
+            return _caller.GetFormat<Properties>("/app/rest/builds/id:{0}/statistics", buildId).Property;
+        }
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/Build.cs
+++ b/src/TeamCitySharp/DomainEntities/Build.cs
@@ -7,7 +7,7 @@ namespace TeamCitySharp.DomainEntities
         public string Id { get; set; }
         public string Number { get; set; }
         public string Status { get; set; }
-        public string BuildTypeId { get; set; }
+        public BuildConfig BuildType { get; set; }
         public string Href { get; set; }
         public string WebUrl { get; set; }
         public string StatusText { get; set; }

--- a/src/TeamCitySharp/ITeamCityClient.cs
+++ b/src/TeamCitySharp/ITeamCityClient.cs
@@ -18,5 +18,6 @@ namespace TeamCitySharp
         IChanges Changes { get; }
         IBuildArtifacts Artifacts { get; }
         ITestOccurrences TestOccurrences { get; }
+        IStatistics Statistics { get; }
     }
 }

--- a/src/TeamCitySharp/TeamCityClient.cs
+++ b/src/TeamCitySharp/TeamCityClient.cs
@@ -16,6 +16,7 @@ namespace TeamCitySharp
         private IChanges _changes;
         private IBuildArtifacts _artifacts;
         private ITestOccurrences _testOccurrences;
+        private IStatistics _statistics;
 
         public TeamCityClient(string hostName, bool useSsl = false)
         {
@@ -85,6 +86,11 @@ namespace TeamCitySharp
         public ITestOccurrences TestOccurrences
         {
             get { return _testOccurrences ?? (_testOccurrences = new TestOccurrences(_caller)); }
+        }
+
+        public IStatistics Statistics
+        {
+            get { return _statistics ?? (_statistics = new Statistics(_caller)); }
         }
     }
 }

--- a/src/TeamCitySharp/TeamCitySharp.csproj
+++ b/src/TeamCitySharp/TeamCitySharp.csproj
@@ -63,11 +63,13 @@
     <Compile Include="ActionTypes\IChanges.cs" />
     <Compile Include="ActionTypes\IProjects.cs" />
     <Compile Include="ActionTypes\IServerInformation.cs" />
+    <Compile Include="ActionTypes\IStatistics.cs" />
     <Compile Include="ActionTypes\ITestOccurrences.cs" />
     <Compile Include="ActionTypes\IUsers.cs" />
     <Compile Include="ActionTypes\IVcsRoots.cs" />
     <Compile Include="ActionTypes\Projects.cs" />
     <Compile Include="ActionTypes\ServerInformation.cs" />
+    <Compile Include="ActionTypes\Statistics.cs" />
     <Compile Include="ActionTypes\TestOccurrences.cs" />
     <Compile Include="Connection\ITeamCityCaller.cs" />
     <Compile Include="DomainEntities\TestOccurrence.cs" />

--- a/src/Tests/IntegrationTests/SampleStatisticsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleStatisticsUsage.cs
@@ -1,0 +1,28 @@
+﻿using NUnit.Framework;
+using System.Linq;
+
+namespace TeamCitySharp.IntegrationTests
+{
+    [TestFixture]
+    public class when_interacting_to_get_build_statistics
+    {
+        private ITeamCityClient _client;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _client = new TeamCityClient("teamcity.codebetter.com");
+            _client.Connect("teamcitysharpuser", "qwerty");
+        }
+
+        [Test]
+        public void it_returns_no_of_tests_from_last_successful_build()
+        {
+            var proj = _client.Projects.ById("AutoFixture"); 
+            var build = _client.Builds.LastSuccessfulBuildByBuildConfigId(proj.BuildTypes.BuildType[0].Id);
+            var stats = _client.Statistics.GetByBuildId(build.Id);
+
+            Assert.That(stats.Any(property => property.Name.Equals("PassedTestCount")));
+        }
+   }
+}

--- a/src/Tests/IntegrationTests/TeamCitySharp.IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/TeamCitySharp.IntegrationTests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="SampleServerUsage.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="SampleStatisticsUsage.cs" />
     <Compile Include="SampleUserUsage.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
Hi

I've added support for test statistics and changed Build entity to retrieve BuildType information when getting BuildType information.

Can you review and accept this into your repository?

Thanks and keep the good work
Carlos Camacho
