### PR TITLE
Load Project parent/children from API response

### DIFF
--- a/src/TeamCitySharp/DomainEntities/Project.cs
+++ b/src/TeamCitySharp/DomainEntities/Project.cs
@@ -7,6 +7,7 @@
             return Name;
         }
 
+        public string ParentProjectId { get; set; }
         public bool Archived { get; set; }
         public string Description { get; set; }
         public string Href { get; set; }
@@ -16,5 +17,6 @@
 
         public BuildTypeWrapper BuildTypes { get; set; }
         public Parameters Parameters { get; set; }
+        public Projects Projects { get; set; }
     }
 }

--- a/src/TeamCitySharp/DomainEntities/Projects.cs
+++ b/src/TeamCitySharp/DomainEntities/Projects.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class Projects
+    {
+        public override string ToString()
+        {
+            return "projects";
+        }
+
+        public List<Project> Project { get; set; }
+    }
+}

--- a/src/TeamCitySharp/TeamCitySharp.csproj
+++ b/src/TeamCitySharp/TeamCitySharp.csproj
@@ -72,6 +72,7 @@
     <Compile Include="ActionTypes\Statistics.cs" />
     <Compile Include="ActionTypes\TestOccurrences.cs" />
     <Compile Include="Connection\ITeamCityCaller.cs" />
+    <Compile Include="DomainEntities\Projects.cs" />
     <Compile Include="DomainEntities\TestOccurrence.cs" />
     <Compile Include="DomainEntities\TestOccurrenceWrapper.cs" />
     <Compile Include="Locators\ChangeLocator.cs" />


### PR DESCRIPTION
Hi,

This fork seemed to be the most up-to-date TeamCitySharp fork I could find, so I wanted to send in a minor enhancement I made.

This adds support to the Project entity, to read in the parentProjectId and child project collection details from the REST API response.  This allows better navigating of the project structure (being able to find a project's parent by it's Id, or iterate through it's children)
